### PR TITLE
Email Commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": "^7.4|^8.0",
         "google/apiclient": "^2.7",
         "tipoff/authorization": "^1.0.1",
+        "tipoff/locations": "^2.0",
         "tipoff/support": "^1.3.0"
     },
     "require-dev": {

--- a/resources/views/emails/reviews/month.blade.php
+++ b/resources/views/emails/reviews/month.blade.php
@@ -1,0 +1,19 @@
+@component('mail::message')
+    # Google Reviews in {{ $month }}
+
+    Below are the number of reviews generated in {{ $month }}:
+
+    @component('mail::table')
+        | Location | Reviews |
+        | -- | :--: |
+        @foreach ($locations as $location)
+            | {{ $location->name }} | {{ $location->reviews_count }} |
+        @endforeach
+    @endcomponent
+
+    Feel free to contact me if you have any questions regarding your goals. Keep pushing to generate more reviews and continue making them a priority in your operations.
+
+    Thank you,
+
+    -Drew
+@endcomponent

--- a/resources/views/emails/reviews/week.blade.php
+++ b/resources/views/emails/reviews/week.blade.php
@@ -1,0 +1,27 @@
+@component('mail::message')
+    # Google Reviews This Week
+
+    Below are the number of Google Reviews each of our locations received this week. I'll send another one of these emails out on Monday with the weekend totals.
+
+    Let's continue to make a strong push on Google Reviews and encourage your staff to be bold in asking for them this weekend.
+
+    @component('mail::table')
+        | Location | Reviews |
+        | -- | :--: |
+        @foreach ($locations as $location)
+            | {{ $location->name }} | {{ $location->reviews_count }} |
+        @endforeach
+    @endcomponent
+
+    To view your reviews and respond to them, visit Google My Business:
+
+    @component('mail::button', ['url' => 'https://business.google.com/reviews'])
+        Google My Business
+    @endcomponent
+
+    Let me know if you have any questions.
+
+    Thank you,
+
+    -Drew
+@endcomponent

--- a/resources/views/emails/reviews/weekend.blade.php
+++ b/resources/views/emails/reviews/weekend.blade.php
@@ -1,0 +1,25 @@
+@component('mail::message')
+    # Google Reviews This Weekend
+
+    Below are the number of Google Reviews each of our locations received over the weekend.
+
+    @component('mail::table')
+        | Location | Reviews |
+        | -- | :--: |
+        @foreach ($locations as $location)
+            | {{ $location->name }} | {{ $location->reviews_count }} |
+        @endforeach
+    @endcomponent
+
+    To view your reviews and respond to them, visit Google My Business:
+
+    @component('mail::button', ['url' => 'https://business.google.com/reviews'])
+        Google My Business
+    @endcomponent
+
+    Let me know if you have any questions.
+
+    Thank you,
+
+    -Drew
+@endcomponent

--- a/resources/views/snapshots/month.blade.php
+++ b/resources/views/snapshots/month.blade.php
@@ -1,0 +1,23 @@
+@component('mail::message')
+    # {{ $market->name }} Reviews in {{ $month }}
+
+    Here is a snapshot of the total Google Reviews for each {{ $market->name }} escape room company and the new reviews generated in {{ $month }}.
+
+    @component('mail::table')
+        | Company | New | Total |
+        | -- | :--: | :--: |
+        @foreach ($competitors as $competitor)
+            @if ($competitor->competitor == 0)
+                | **[{{ $competitor->name }}]({{ $competitor->maps_url }})** | **{{ $competitor->monthly_reviews }}** | **{{ $competitor->reviews }}** |
+            @else
+                | [{{ $competitor->name }}]({{ $competitor->maps_url }}) | {{ $competitor->monthly_reviews }} | {{ $competitor->reviews }} |
+            @endif
+        @endforeach
+    @endcomponent
+
+    Let me know if you have any questions.
+
+    Thanks,
+
+    -Drew
+@endcomponent

--- a/resources/views/snapshots/top.blade.php
+++ b/resources/views/snapshots/top.blade.php
@@ -1,0 +1,21 @@
+@component('mail::message')
+    # Top 25 - Weekly Review Race
+
+    For comparison purposes, here are the Top 25 escape rooms with the most reviews over the past week in our markets.
+
+    @component('mail::table')
+        | Company | Reviews |
+        | -- | :--: |
+        @foreach ($competitors as $competitor)
+            @if ($competitor->competitor == 0)
+                | **[{{ $competitor->name }}]({{ $competitor->maps_url }})** | **{{ $competitor->weekly_reviews }}** |
+            @else
+                | [{{ $competitor->name }}]({{ $competitor->maps_url }}) | {{ $competitor->weekly_reviews }} |
+            @endif
+        @endforeach
+    @endcomponent
+
+    I'll send out another one of these emails next Wednesday so continue working hard to make the top of this list.
+
+    -Drew
+@endcomponent

--- a/resources/views/snapshots/week.blade.php
+++ b/resources/views/snapshots/week.blade.php
@@ -1,0 +1,23 @@
+@component('mail::message')
+    # Weekly Race for Reviews
+
+    Below are the total number of Google Reviews that were generated since last Wednesday compared to your competitors in {{ $market->name }}:
+
+    @component('mail::table')
+        | Company | Reviews |
+        | -- | :--: |
+        @foreach ($competitors as $competitor)
+            @if ($competitor->competitor == 0)
+                | **[{{ $competitor->name }}]({{ $competitor->maps_url }})** | **{{ $competitor->weekly_reviews }}** |
+            @else
+                | [{{ $competitor->name }}]({{ $competitor->maps_url }}) | {{ $competitor->weekly_reviews }} |
+            @endif
+        @endforeach
+    @endcomponent
+
+    Let me know if you have any questions and keep pushing to generate significantly more reviews each week than your competition. I'll send out another one of these emails next Wednesday so you can continue tracking your progress.
+
+    Keep Racing!
+
+    -Drew
+@endcomponent

--- a/src/Commands/SendReviewMonthEmail.php
+++ b/src/Commands/SendReviewMonthEmail.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Commands;
+
+use Tipoff\Reviews\Mail\ReviewMonth;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendReviewMonthEmail extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send:reviewmonth';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send the last month recap of Google Reviews';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $managers = [
+            'orlandomgr@thegreatescaperoom.com',
+            'tampamgr@thegreatescaperoom.com',
+            'jacksonvillemgr@thegreatescaperoom.com',
+            'akronmgr@thegreatescaperoom.com',
+            'grandrapidsmgr@thegreatescaperoom.com',
+            'providencemgr@thegreatescaperoom.com',
+            'rochestermgr@thegreatescaperoom.com',
+            'chicagomgr@thegreatescaperoom.com',
+            'royaloakmgr@thegreatescaperoom.com',
+            'pittsburghmgr@thegreatescaperoom.com',
+        ];
+        $execs = [
+            'kirk@thegreatescaperoom.com',
+            'julie@thegreatescaperoom.com',
+            'nicole@thegreatescaperoom.com',
+            'kelleigh@thegreatescaperoom.com',
+            'scott@thegreatescaperoom.com',
+            'igug@thegreatescaperoom.com',
+        ];
+
+        Mail::to($managers)
+            ->cc($execs)
+            ->bcc('digitalmgr@thegreatescaperoom.com')
+            ->send(new ReviewMonth());
+    }
+}

--- a/src/Commands/SendReviewMonthEmail.php
+++ b/src/Commands/SendReviewMonthEmail.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Commands;
 
-use Tipoff\Reviews\Mail\ReviewMonth;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
+use Tipoff\Reviews\Mail\ReviewMonth;
 
 class SendReviewMonthEmail extends Command
 {

--- a/src/Commands/SendReviewWeekendEmail.php
+++ b/src/Commands/SendReviewWeekendEmail.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Commands;
+
+use Tipoff\Reviews\Mail\ReviewWeekend;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendReviewWeekendEmail extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send:reviewweekend';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send the Monday recap of Google Reviews over the weekend';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $managers = [
+            'orlandomgr@thegreatescaperoom.com',
+            'tampamgr@thegreatescaperoom.com',
+            'jacksonvillemgr@thegreatescaperoom.com',
+            'akronmgr@thegreatescaperoom.com',
+            'grandrapidsmgr@thegreatescaperoom.com',
+            'providencemgr@thegreatescaperoom.com',
+            'rochestermgr@thegreatescaperoom.com',
+            'chicagomgr@thegreatescaperoom.com',
+            'royaloakmgr@thegreatescaperoom.com',
+            'pittsburghmgr@thegreatescaperoom.com',
+        ];
+        $execs = [
+            'kirk@thegreatescaperoom.com',
+            'julie@thegreatescaperoom.com',
+            'nicole@thegreatescaperoom.com',
+            'kelleigh@thegreatescaperoom.com',
+            'scott@thegreatescaperoom.com',
+            'igug@thegreatescaperoom.com',
+        ];
+
+        Mail::to($managers)
+            ->cc($execs)
+            ->bcc('digitalmgr@thegreatescaperoom.com')
+            ->send(new ReviewWeekend());
+    }
+}

--- a/src/Commands/SendReviewWeekendEmail.php
+++ b/src/Commands/SendReviewWeekendEmail.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Commands;
 
-use Tipoff\Reviews\Mail\ReviewWeekend;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
+use Tipoff\Reviews\Mail\ReviewWeekend;
 
 class SendReviewWeekendEmail extends Command
 {

--- a/src/Commands/SendSnapshotMonthEmails.php
+++ b/src/Commands/SendSnapshotMonthEmails.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Commands;
 
-use Tipoff\Reviews\Mail\SnapshotMonth;
-use Tipoff\Locations\Models\Market;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Reviews\Mail\SnapshotMonth;
 
 class SendSnapshotMonthEmails extends Command
 {

--- a/src/Commands/SendSnapshotMonthEmails.php
+++ b/src/Commands/SendSnapshotMonthEmails.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Commands;
+
+use Tipoff\Reviews\Mail\SnapshotMonth;
+use Tipoff\Locations\Models\Market;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendSnapshotMonthEmails extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send:snapshotmonth';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send the monthly snapshots of our competitors reviews';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $markets = Market::where('corporate', 1)->get();
+        foreach ($markets as $market) {
+            Mail::send(new SnapshotMonth($market));
+        }
+    }
+}

--- a/src/Commands/SendSnapshotTopEmail.php
+++ b/src/Commands/SendSnapshotTopEmail.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Commands;
 
-use Tipoff\Reviews\Mail\SnapshotTop;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
+use Tipoff\Reviews\Mail\SnapshotTop;
 
 class SendSnapshotTopEmail extends Command
 {

--- a/src/Commands/SendSnapshotTopEmail.php
+++ b/src/Commands/SendSnapshotTopEmail.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Commands;
+
+use Tipoff\Reviews\Mail\SnapshotTop;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendSnapshotTopEmail extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send:snapshottop';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send the weekly Top 25 snapshots of our competitors reviews';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Mail::send(new SnapshotTop());
+    }
+}

--- a/src/Commands/SendSnapshotWeekEmails.php
+++ b/src/Commands/SendSnapshotWeekEmails.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Commands;
+
+use Tipoff\Reviews\Mail\SnapshotWeek;
+use Tipoff\Locations\Models\Market;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendSnapshotWeekEmails extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send:snapshotweek';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send the weekly snapshots of our competitors reviews';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $markets = Market::where('corporate', 1)->where('id', '<>', 8)->get();
+        foreach ($markets as $market) {
+            Mail::send(new SnapshotWeek($market));
+        }
+    }
+}

--- a/src/Commands/SendSnapshotWeekEmails.php
+++ b/src/Commands/SendSnapshotWeekEmails.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Commands;
 
-use Tipoff\Reviews\Mail\SnapshotWeek;
-use Tipoff\Locations\Models\Market;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Reviews\Mail\SnapshotWeek;
 
 class SendSnapshotWeekEmails extends Command
 {

--- a/src/Mail/ReviewMonth.php
+++ b/src/Mail/ReviewMonth.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Mail;
+
+use Tipoff\Locations\Models\Location;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class ReviewMonth extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $locations;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->locations = Location::where('corporate', 1)->withCount(['reviews' => function ($query) {
+            $query->where('reviewed_at', '>', Carbon::now('America/New_York')
+                ->startOfMonth()
+                ->subMonth()
+                ->setTimeZone('UTC')
+                ->format('Y-m-d H:i:s'))
+                ->where('reviewed_at', '<', Carbon::now('America/New_York')
+                    ->subMonth()
+                    ->endOfMonth()
+                    ->setTimeZone('UTC')
+                    ->format('Y-m-d H:i:s'));
+        }])->orderByDesc('reviews_count')->get();
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $locations = $this->locations;
+        $month = Carbon::now()->subMonth()->format('F');
+        $this->withSwiftMessage(function ($message) {
+            $message->getHeaders()
+                ->addTextHeader('tag', 'reviewmonth');
+        });
+
+        return $this->markdown('emails.reviews.month')
+            ->subject($month . ' Review Totals')
+            ->with([
+                'locations' => $locations,
+                'month' => $month,
+            ]);
+    }
+}

--- a/src/Mail/ReviewMonth.php
+++ b/src/Mail/ReviewMonth.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Mail;
 
-use Tipoff\Locations\Models\Location;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Tipoff\Locations\Models\Location;
 
 class ReviewMonth extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     public $locations;
 

--- a/src/Mail/ReviewWeekend.php
+++ b/src/Mail/ReviewWeekend.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Mail;
 
-use Tipoff\Locations\Models\Location;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Tipoff\Locations\Models\Location;
 
 class ReviewWeekend extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     public $locations;
 

--- a/src/Mail/ReviewWeekend.php
+++ b/src/Mail/ReviewWeekend.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Mail;
+
+use Tipoff\Locations\Models\Location;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class ReviewWeekend extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $locations;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->locations = Location::where('corporate', 1)->withCount(['reviews' => function ($query) {
+            $query->where('reviewed_at', '>', Carbon::parse('last friday', 'America/New_York')
+                ->setTimeZone('UTC')
+                ->format('Y-m-d H:i:s'))
+                ->where('reviewed_at', '<', Carbon::parse('last friday', 'America/New_York')
+                    ->setTimeZone('UTC')->addDays(3)
+                    ->format('Y-m-d H:i:s'));
+        }])->orderByDesc('reviews_count')->get();
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $locations = $this->locations;
+        $this->withSwiftMessage(function ($message) {
+            $message->getHeaders()
+                ->addTextHeader('tag', 'reviewweekend');
+        });
+
+        return $this->markdown('emails.reviews.weekend')
+            ->subject('Google Reviews - ' . Carbon::parse('last saturday', 'America/New_York')->format('M j') . ' Weekend')
+            ->with([
+                'locations' => $locations,
+            ]);
+    }
+}

--- a/src/Mail/SnapshotMonth.php
+++ b/src/Mail/SnapshotMonth.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Mail;
+
+use Tipoff\Reviews\Models\Competitor;
+use Tipoff\Locations\Models\Market;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class SnapshotMonth extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $competitors;
+    public $market;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param Market $market
+     */
+    public function __construct(Market $market)
+    {
+        $this->market = $market;
+
+        $competitors = Competitor::where('market_id', $market->id)->get();
+        $this->competitors = $competitors->sortByDesc('reviews');
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $execs = [
+            'kirk@thegreatescaperoom.com',
+            'julie@thegreatescaperoom.com',
+            'nicole@thegreatescaperoom.com',
+            'kelleigh@thegreatescaperoom.com',
+            'callcenter@thegreatescaperoom.com',
+            'scott@thegreatescaperoom.com',
+            'igug@thegreatescaperoom.com',
+        ];
+
+        $competitors = $this->competitors;
+        $market = $this->market;
+        $month = Carbon::now()->subMonth()->format('F');
+        $this->withSwiftMessage(function ($message) {
+            $message->getHeaders()->addTextHeader('tag', 'snapshotmonth');
+        });
+
+
+        if (isset($market->locations->first()->manager->email) && $market->locations->first()->manager->email !== $market->locations()->first()->contact_email) {
+            $locationemails = [
+                $market->locations()->first()->contact_email,
+                $market->locations()->first()->manager->email,
+            ];
+        } else {
+            $locationemails = $market->locations()->first()->contact_email;
+        }
+
+        return $this->markdown('emails.snapshots.month')
+            ->to($locationemails)
+            ->cc($execs)
+            ->bcc('digitalmgr@thegreatescaperoom.com')
+            ->subject($market->name . ' Reviews in ' . $month)
+            ->with([
+                'competitors' => $competitors,
+                'market' => $market,
+                'month' => $month,
+            ]);
+    }
+}

--- a/src/Mail/SnapshotMonth.php
+++ b/src/Mail/SnapshotMonth.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Mail;
 
-use Tipoff\Reviews\Models\Competitor;
-use Tipoff\Locations\Models\Market;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Reviews\Models\Competitor;
 
 class SnapshotMonth extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     public $competitors;
     public $market;

--- a/src/Mail/SnapshotTop.php
+++ b/src/Mail/SnapshotTop.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Mail;
 
-use Tipoff\Reviews\Models\Competitor;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Tipoff\Reviews\Models\Competitor;
 
 class SnapshotTop extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     public $competitors;
 

--- a/src/Mail/SnapshotTop.php
+++ b/src/Mail/SnapshotTop.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Mail;
+
+use Tipoff\Reviews\Models\Competitor;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class SnapshotTop extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $competitors;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $competitors = Competitor::whereNotNull('market_id')->get();
+        $this->competitors = $competitors->sortByDesc('weekly_reviews')->take(25);
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $managers = [
+            'orlandomgr@thegreatescaperoom.com',
+            'orlando@thegreatescaperoom.com',
+            'tampamgr@thegreatescaperoom.com',
+            'tampa@thegreatescaperoom.com',
+            'jacksonvillemgr@thegreatescaperoom.com',
+            'jacksonville@thegreatescaperoom.com',
+            'akronmgr@thegreatescaperoom.com',
+            'akron@thegreatescaperoom.com',
+            'grandrapidsmgr@thegreatescaperoom.com',
+            'grandrapids@thegreatescaperoom.com',
+            'providencemgr@thegreatescaperoom.com',
+            'providence@thegreatescaperoom.com',
+            'rochestermgr@thegreatescaperoom.com',
+            'rochester@thegreatescaperoom.com',
+            'chicagomgr@thegreatescaperoom.com',
+            'chicago@thegreatescaperoom.com',
+            'royaloakmgr@thegreatescaperoom.com',
+            'royaloak@thegreatescaperoom.com',
+        ];
+        $execs = [
+            'kirk@thegreatescaperoom.com',
+            'julie@thegreatescaperoom.com',
+            'nicole@thegreatescaperoom.com',
+            'kelleigh@thegreatescaperoom.com',
+            'callcenter@thegreatescaperoom.com',
+            'scott@thegreatescaperoom.com',
+            'igug@thegreatescaperoom.com',
+        ];
+
+        $competitors = $this->competitors;
+        $this->withSwiftMessage(function ($message) {
+            $message->getHeaders()->addTextHeader('tag', 'snapshottop');
+        });
+
+        return $this->markdown('emails.snapshots.top')
+            ->to($managers)
+            ->cc($execs)
+            ->bcc('digitalmgr@thegreatescaperoom.com')
+            ->subject('Top 25 - Weekly Review Race - ' . Carbon::now('America/New_York')->format('M j'))
+            ->with([
+                'competitors' => $competitors,
+            ]);
+    }
+}

--- a/src/Mail/SnapshotWeek.php
+++ b/src/Mail/SnapshotWeek.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Mail;
+
+use Tipoff\Reviews\Models\Competitor;
+use Tipoff\Locations\Models\Market;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class SnapshotWeek extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $market;
+    public $competitors;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param Market $market
+     */
+    public function __construct(Market $market)
+    {
+        $this->market = $market;
+
+        $competitors = Competitor::where('market_id', $market->id)->get();
+        $this->competitors = $competitors->sortByDesc('weekly_reviews');
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $competitors = $this->competitors;
+        $market = $this->market;
+        $this->withSwiftMessage(function ($message) {
+            $message->getHeaders()->addTextHeader('tag', 'snapshotweek');
+        });
+
+        if (isset($market->locations->first()->manager->email) && $market->locations->first()->manager->email !== $market->locations->first()->contact_email) {
+            $locationemails = [
+                $market->locations->first()->contact_email,
+                $market->locations->first()->manager->email,
+            ];
+        } else {
+            $locationemails = $market->locations->first()->contact_email;
+        }
+
+        $execs = [
+            'kirk@thegreatescaperoom.com',
+            'julie@thegreatescaperoom.com',
+            'nicole@thegreatescaperoom.com',
+            'kelleigh@thegreatescaperoom.com',
+            'callcenter@thegreatescaperoom.com',
+            'scott@thegreatescaperoom.com',
+            'igug@thegreatescaperoom.com',
+        ];
+
+        return $this->markdown('emails.snapshots.week')
+            ->to($locationemails)
+            ->cc($execs)
+            ->bcc('digitalmgr@thegreatescaperoom.com')
+            ->subject($market->name . ' Review Race - ' . Carbon::now('America/New_York')->format('M j'))
+            ->with([
+                'competitors' => $competitors,
+                'market' => $market,
+            ]);
+    }
+}

--- a/src/Mail/SnapshotWeek.php
+++ b/src/Mail/SnapshotWeek.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews\Mail;
 
-use Tipoff\Reviews\Models\Competitor;
-use Tipoff\Locations\Models\Market;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Reviews\Models\Competitor;
 
 class SnapshotWeek extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     public $market;
     public $competitors;

--- a/src/Nova/Review.php
+++ b/src/Nova/Review.php
@@ -34,7 +34,7 @@ class Review extends BaseResource
 
     /** @psalm-suppress UndefinedClass */
     protected array $filterClassList = [
-        Location::class
+        Location::class,
     ];
 
     public function fieldsForIndex(NovaRequest $request)

--- a/src/Nova/Review.php
+++ b/src/Nova/Review.php
@@ -18,6 +18,7 @@ use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;
+use Tippoff\Locations\Nova\Filters\Location;
 
 class Review extends BaseResource
 {
@@ -33,7 +34,7 @@ class Review extends BaseResource
 
     /** @psalm-suppress UndefinedClass */
     protected array $filterClassList = [
-        \Tipoff\Locations\Nova\Filters\Location::class,
+        Location::class
     ];
 
     public function fieldsForIndex(NovaRequest $request)

--- a/src/ReviewsServiceProvider.php
+++ b/src/ReviewsServiceProvider.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Tipoff\Reviews;
 
+use Tipoff\Reviews\Commands\SendReviewMonthEmail;
+use Tipoff\Reviews\Commands\SendReviewWeekendEmail;
+use Tipoff\Reviews\Commands\SendSnapshotMonthEmails;
+use Tipoff\Reviews\Commands\SendSnapshotTopEmail;
+use Tipoff\Reviews\Commands\SendSnapshotWeekEmails;
 use Tipoff\Reviews\Models\Competitor;
 use Tipoff\Reviews\Models\Insight;
 use Tipoff\Reviews\Models\Review;
@@ -26,7 +31,15 @@ class ReviewsServiceProvider extends TipoffServiceProvider
                 Review::class => ReviewPolicy::class,
                 Snapshot::class => SnapshotPolicy::class,
             ])
+            ->hasCommands([
+                SendReviewMonthEmail::class,
+                SendReviewWeekendEmail::class,
+                SendSnapshotMonthEmails::class,
+                SendSnapshotTopEmail::class,
+                SendSnapshotWeekEmails::class,
+            ])
             ->name('reviews')
+            ->hasViews()
             ->hasConfigFile();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Reviews\Tests;
 
 use Laravel\Nova\NovaCoreServiceProvider;
+use Tipoff\Locations\LocationsServiceProvider;
 use Tipoff\Reviews\ReviewsServiceProvider;
 use Tipoff\Reviews\Tests\Support\Providers\NovaTestbenchServiceProvider;
 use Tipoff\Support\SupportServiceProvider;
@@ -17,8 +18,9 @@ class TestCase extends BaseTestCase
         return [
             NovaCoreServiceProvider::class,
             NovaTestbenchServiceProvider::class,
-            SupportServiceProvider::class,
             ReviewsServiceProvider::class,
+            SupportServiceProvider::class,
+            LocationsServiceProvider::class,
         ];
     }
 }

--- a/tests/Unit/Mail/ReviewMonthTest.php
+++ b/tests/Unit/Mail/ReviewMonthTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Tests\Unit\Mail;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
+use Tipoff\Reviews\Mail\ReviewMonth;
+use Tipoff\Reviews\Tests\TestCase;
+
+class ReviewMonthTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    //Todo: Need to figure out how to test markdown content
+
+    /** @test */
+    public function email()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        Mail::to('test@example.com')->send(new ReviewMonth());
+        Mail::assertSent(ReviewMonth::class);
+    }
+}

--- a/tests/Unit/Mail/ReviewWeekendTest.php
+++ b/tests/Unit/Mail/ReviewWeekendTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Tests\Unit\Mail;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
+use Tipoff\Reviews\Mail\ReviewWeekend;
+use Tipoff\Reviews\Tests\TestCase;
+
+class ReviewWeekendTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    //Todo: Need to figure out how to test markdown content
+
+    /** @test */
+    public function email()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        Mail::to('test@example.com')->send(new ReviewWeekend());
+        Mail::assertSent(ReviewWeekend::class);
+    }
+}

--- a/tests/Unit/Mail/SnapshotMonthTest.php
+++ b/tests/Unit/Mail/SnapshotMonthTest.php
@@ -28,10 +28,10 @@ class SnapshotMonthTest extends TestCase
         $market = Market::factory()->create();
         Location::factory()->create([
             'market_id' => $market->id,
-            'manager_id' => User::factory()->create()->id
+            'manager_id' => User::factory()->create()->id,
         ]);
         Competitor::factory()->create([
-            'market_id' => $market->id
+            'market_id' => $market->id,
         ]);
         Mail::send(new SnapshotMonth($market));
         Mail::assertSent(function (SnapshotMonth $mail) use ($market) {

--- a/tests/Unit/Mail/SnapshotMonthTest.php
+++ b/tests/Unit/Mail/SnapshotMonthTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Tests\Unit\Mail;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
+use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Reviews\Mail\SnapshotMonth;
+use Tipoff\Reviews\Models\Competitor;
+use Tipoff\Reviews\Tests\TestCase;
+use Tipoff\TestSupport\Models\User;
+
+class SnapshotMonthTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    //Todo: Need to figure out how to test markdown content
+
+    /** @test */
+    public function email()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        $market = Market::factory()->create();
+        Location::factory()->create([
+            'market_id' => $market->id,
+            'manager_id' => User::factory()->create()->id
+        ]);
+        Competitor::factory()->create([
+            'market_id' => $market->id
+        ]);
+        Mail::send(new SnapshotMonth($market));
+        Mail::assertSent(function (SnapshotMonth $mail) use ($market) {
+            $mail->build();
+
+            return $mail->market->id === $market->id &&
+                $mail->hasTo($market->locations->first()->contact_email) &&
+                $mail->hasCc('kirk@thegreatescaperoom.com') &&
+                $mail->hasBcc('digitalmgr@thegreatescaperoom.com');
+        });
+    }
+}

--- a/tests/Unit/Mail/SnapshotTopTest.php
+++ b/tests/Unit/Mail/SnapshotTopTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Tests\Unit\Mail;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
+use Tipoff\Reviews\Mail\SnapshotTop;
+use Tipoff\Reviews\Tests\TestCase;
+
+class SnapshotTopTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    //Todo: Need to figure out how to test markdown content
+
+    /** @test */
+    public function email()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        Mail::send(new SnapshotTop());
+        Mail::assertSent(function (SnapshotTop $mail) {
+            $mail->build();
+
+            return $mail->hasCc('kirk@thegreatescaperoom.com') &&
+                $mail->hasBcc('digitalmgr@thegreatescaperoom.com');
+        });
+    }
+}

--- a/tests/Unit/Mail/SnapshotWeekTest.php
+++ b/tests/Unit/Mail/SnapshotWeekTest.php
@@ -28,10 +28,10 @@ class SnapshotWeekTest extends TestCase
         $market = Market::factory()->create();
         Location::factory()->create([
             'market_id' => $market->id,
-            'manager_id' => User::factory()->create()->id
+            'manager_id' => User::factory()->create()->id,
         ]);
         Competitor::factory()->create([
-            'market_id' => $market->id
+            'market_id' => $market->id,
         ]);
         Mail::send(new SnapshotWeek($market));
         Mail::assertSent(function (SnapshotWeek $mail) use ($market) {

--- a/tests/Unit/Mail/SnapshotWeekTest.php
+++ b/tests/Unit/Mail/SnapshotWeekTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Reviews\Tests\Unit\Mail;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
+use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Reviews\Mail\SnapshotWeek;
+use Tipoff\Reviews\Models\Competitor;
+use Tipoff\Reviews\Tests\TestCase;
+use Tipoff\TestSupport\Models\User;
+
+class SnapshotWeekTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    //Todo: Need to figure out how to test markdown content
+
+    /** @test */
+    public function email()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        $market = Market::factory()->create();
+        Location::factory()->create([
+            'market_id' => $market->id,
+            'manager_id' => User::factory()->create()->id
+        ]);
+        Competitor::factory()->create([
+            'market_id' => $market->id
+        ]);
+        Mail::send(new SnapshotWeek($market));
+        Mail::assertSent(function (SnapshotWeek $mail) use ($market) {
+            $mail->build();
+
+            return $mail->market->id === $market->id &&
+                $mail->hasTo($market->locations->first()->contact_email) &&
+                $mail->hasCc('kirk@thegreatescaperoom.com') &&
+                $mail->hasBcc('digitalmgr@thegreatescaperoom.com');
+        });
+    }
+}


### PR DESCRIPTION
Added the following commands:
- SendReviewMonthEmail
- SendReviewWeekendEmail
- SendSnapshotMonthEmails
- SendSnapshotTopEmail
- SendSnapshotWeekEmails

These commands all had corresponding Mailables, so those have been added along with tests for each one. While this PR does not contain all the commands for this package, other commands involve work MyBusiness, which is being refactored elswhere as of now. I can attempt to add those if desired as of now.

While the import of commands was pretty straight foward, I ran into an issue when dealing with Snapshot Mailables:

```
$market = Market::factory()->create();
Location::factory()->create([
    'market_id' => $market->id,
    'manager_id' => User::factory()->create()->id
]);
Competitor::factory()->create([
    'market_id' => $market->id
]);
```

It takes 4 different factories to achieve the data required within some of the Snapshot Mailables. In addition, there's a call to check for a manager's email:

`$market->locations->first()->manager->email`

Using `Tipoff\TestSupport\Models\User` does not appear to provide an email field for use, so there may need to be discussion into possibly refactoring those mailables or perhaps another way I could approach refactoring these mailables.